### PR TITLE
Removed deprecated twig tags

### DIFF
--- a/Resources/views/json-ld.html.twig
+++ b/Resources/views/json-ld.html.twig
@@ -1,24 +1,22 @@
 {% if wo_breadcrumbs()|length %}
-    {%- apply spaceless -%}
-        <script type="application/ld+json">
-        {
-            "@context": "http://schema.org",
-            "@type": "BreadcrumbList",
-            "itemListElement":
-            [
-                {% for b in breadcrumbs %}
+    <script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement":
+        [
+            {% for b in breadcrumbs %}
+                {
+                    "@type": "ListItem",
+                    "position": {{ loop.index }},
+                    "item":
                     {
-                        "@type": "ListItem",
-                        "position": {{ loop.index }},
-                        "item":
-                        {
-                            "@id": "{{ b.url }}",
-                            "name": "{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}"
-                        }
-                    }{% if not loop.last %},{% endif %}
-                {% endfor %}
-            ]
-        }
-        </script>
-    {%- endapply -%}
+                        "@id": "{{ b.url }}",
+                        "name": "{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}"
+                    }
+                }{% if not loop.last %},{% endif %}
+            {% endfor %}
+        ]
+    }
+    </script>
 {% endif %}

--- a/Resources/views/microdata.html.twig
+++ b/Resources/views/microdata.html.twig
@@ -1,24 +1,22 @@
 {% if wo_breadcrumbs()|length %}
-    {%- apply spaceless -%}
-        <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://schema.org/BreadcrumbList">
-            {% for b in breadcrumbs %}
-                <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %} itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+    <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://schema.org/BreadcrumbList">
+        {% for b in breadcrumbs %}
+            <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %} itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                {% if b.url and not loop.last %}
+                <a href="{{ b.url }}" itemprop="item"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
+                    {% endif %}
+                    <span itemprop="name">{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}</span>
                     {% if b.url and not loop.last %}
-                    <a href="{{ b.url }}" itemprop="item"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
-                        {% endif %}
-                        <span itemprop="name">{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}</span>
-                        {% if b.url and not loop.last %}
-                    </a>
-                    {% elseif b.url %}
-                        <meta itemprop="item" content="{{ b.url }}" />
-                    {% endif %}
-                    <meta itemprop="position" content="{{ loop.index }}" />
+                </a>
+                {% elseif b.url %}
+                    <meta itemprop="item" content="{{ b.url }}" />
+                {% endif %}
+                <meta itemprop="position" content="{{ loop.index }}" />
 
-                    {% if separator is not null and not loop.last %}
-                        <span class='{{ separatorClass }}'>{{ separator }}</span>
-                    {% endif %}
-                </li>
-            {% endfor %}
-        </ol>
-    {% endapply %}
+                {% if separator is not null and not loop.last %}
+                    <span class='{{ separatorClass }}'>{{ separator }}</span>
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ol>
 {% endif %}

--- a/Test/BundleTest.php
+++ b/Test/BundleTest.php
@@ -31,7 +31,7 @@ class BundleTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
         /** @var \WhiteOctober\BreadcrumbsBundle\Twig\Extension\BreadcrumbsExtension $breadcrumbsExtension */
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
-        self::assertSame(
+        self::assertStringEqualsStringIgnoringLineEndings(
 <<<'EOD'
     <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
                     <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
@@ -59,7 +59,7 @@ EOD,
         /** @var \WhiteOctober\BreadcrumbsBundle\Twig\Extension\BreadcrumbsExtension $breadcrumbsExtension */
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
-        self::assertSame(
+        self::assertStringEqualsStringIgnoringLineEndings(
 <<<'EOD'
     <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
                     <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
@@ -90,7 +90,7 @@ EOD,
         /** @var \WhiteOctober\BreadcrumbsBundle\Twig\Extension\BreadcrumbsExtension $breadcrumbsExtension */
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
-        self::assertSame(
+        self::assertStringEqualsStringIgnoringLineEndings(
             <<<'EOD'
     <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
                     <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">

--- a/Test/BundleTest.php
+++ b/Test/BundleTest.php
@@ -32,7 +32,16 @@ class BundleTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
         self::assertSame(
-            '<ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList"><li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">foo</span><meta itemprop="position" content="1" /></li></ol>',
+<<<'EOD'
+    <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                                    <span itemprop="name">foo</span>
+                                    <meta itemprop="position" content="1" />
+
+                            </li>
+            </ol>
+
+EOD,
             $breadcrumbsExtension->renderBreadcrumbs()
         );
     }
@@ -51,7 +60,16 @@ class BundleTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
         self::assertSame(
-            '<ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList"><li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">foo__{name:John}</span><meta itemprop="position" content="1" /></li></ol>',
+<<<'EOD'
+    <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                                    <span itemprop="name">foo__{name:John}</span>
+                                    <meta itemprop="position" content="1" />
+
+                            </li>
+            </ol>
+
+EOD,
             $breadcrumbsExtension->renderBreadcrumbs([
                 'viewTemplate' => '@WhiteOctoberBreadcrumbs/microdata.html.twig'
             ])
@@ -73,7 +91,22 @@ class BundleTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
         $breadcrumbsExtension = $container->get('white_october_breadcrumbs.twig');
 
         self::assertSame(
-            '<ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList"><li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">foo__domain:admin</span><meta itemprop="position" content="1" /><span class=\'separator\'>/</span></li><li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">bar__{name:John}__domain:admin</span><meta itemprop="position" content="2" /></li></ol>',
+            <<<'EOD'
+    <ol id="wo-breadcrumbs" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+                    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                                    <span itemprop="name">foo__domain:admin</span>
+                                    <meta itemprop="position" content="1" />
+
+                                    <span class='separator'>/</span>
+                            </li>
+                    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                                    <span itemprop="name">bar__{name:John}__domain:admin</span>
+                                    <meta itemprop="position" content="2" />
+
+                            </li>
+            </ol>
+
+EOD,
             $breadcrumbsExtension->renderBreadcrumbs([
                 'viewTemplate' => '@WhiteOctoberBreadcrumbs/microdata.html.twig',
                 'translation_domain' => 'admin',


### PR DESCRIPTION
- Removed use of [deprecated](https://twig.symfony.com/doc/3.x/filters/spaceless.html) `spaceless` filter 
- Fixes indentation for the template code that was wrapped by these filters

Related to https://github.com/mhujer/BreadcrumbsBundle/issues/39